### PR TITLE
runx265: Append `--input` before input file

### DIFF
--- a/cachyos-benchmarker
+++ b/cachyos-benchmarker
@@ -46,7 +46,7 @@ runffm() {
 runx265() {
 	local RESFILE="$WORKDIR/runx265" || exit 4
 	/usr/bin/time -f %e -o $RESFILE x265 -p slow -b 6 -o /dev/null \
-	  --no-progress --log-level none $WORKDIR/bosphorus_hd.y4m &
+	  --no-progress --log-level none --input $WORKDIR/bosphorus_hd.y4m &
 	local PID=$!
 	echo -n -e "* ${TNAMES[2]}:\t\t\t"
 	animate 2 && return 0 || return 99


### PR DESCRIPTION
This is needed following x265 update to 4.0

Likely that this will get fixed in upstream mini-benchmarker so we should just cherry-pick this instead in the package instead of merging it.