### PR TITLE
Get cpu freq via lscpu if needed

### DIFF
--- a/cachyos-benchmarker
+++ b/cachyos-benchmarker
@@ -196,7 +196,9 @@ VER="v2.2"
 CDATE=$(date +%F-%H%M)
 RAMSIZE=$(awk '/MemTotal/{print int($2 / 1000)}' /proc/meminfo)
 CPUCORES=$(nproc)
-CPUFREQ=$(awk '{print $1 / 1000000}' /sys/devices/system/cpu/cpufreq/policy0/cpuinfo_max_freq)
+CPUFREQ=$(awk '{print $1 / 1000000}' /sys/devices/system/cpu/cpufreq/policy0/cpuinfo_max_freq 2>/dev/null)
+# obtain the cpu freq via lscpu if the prior command failed
+[ -z "$CPUFREQ" ] && CPUFREQ=$(lscpu | awk '/BogoMIPS:/ { print $2 / 2 / 1000; exit }')
 COEFF="$(python -c "print(round((($CPUCORES + 1) / 2 * $CPUFREQ / 2) ** (1/3),2))")"
 KERNVER="6.6.40"
 # system info will be logged


### PR DESCRIPTION
My system lacks the cpuinfo_max_freq file in /sys path.

This commits checks if CPUFREQ is blank and if yes, obtain the cpu freq via lscpu.

Signed-off-by: Mario Roy <***@gmail.com>