### PR TITLE
Resolve: line 214: command not found (scx_$SCX --version)

### DIFF
--- a/cachyos-benchmarker
+++ b/cachyos-benchmarker
@@ -238,7 +238,7 @@ fi
 if [ -n "$SCX" ] && [ "$SCX" != "none" ]; then
 	# sequence outputs: scx_lavd 1.0.21-g7298f797 x86_64-unknown-linux-gnu | 1.0.21-g7298f797 | 1.0.21
 	SCX_VERSION=$(scx_"$SCX" --version | awk -F'[[:space:]]' '{print $2}' | awk -F'-' '{print $1}')
-	if [ -x "$SCX_VERSION"]; then
+	if [ -n "$SCX_VERSION" ]; then
 		echo "$SCX is version $SCX_VERSION"
 	fi
 fi

--- a/cachyos-benchmarker
+++ b/cachyos-benchmarker
@@ -222,7 +222,7 @@ SCX_VERSION=""
 if [ -f "/sys/kernel/sched_ext/root/ops" ]; then
 	TMP=$(cat "/sys/kernel/sched_ext/root/ops")
 	if [ -n "$TMP" ]; then
-		SCX=$(awk -F'[[:digit:]]' '{print $1}' "/sys/kernel/sched_ext/root/ops" | awk -F'[[:digit:]]' '{print $1}' | sed -rn 's/^(.*)_$/\1/p')
+		SCX=$(awk -F'[[:digit:]]' '{print $1}' "/sys/kernel/sched_ext/root/ops" | sed -rn 's/^(.*)_$/\1/p')
 		SCX_VERSION=$(sed -rn 's/^[^0-9]*([0-9]+(\.[0-9]+)+).*$/\1/p' "/sys/kernel/sched_ext/root/ops")
 	fi
 fi

--- a/cachyos-benchmarker
+++ b/cachyos-benchmarker
@@ -211,13 +211,31 @@ COEFF="$(python -c "print(round((($CPUCORES + 1) / 2 * $CPUFREQ / 2) ** (1/3),2)
 KERNVER="6.14.7"
 # system info will be logged
 SYSINFO=$(inxi -CmSz -c0 -y-1 | sed -e "s/Array.*:.*//;/^\s*$/d")
-if [ -f /sys/kernel/sched_ext/root/ops ]; then
-    SCX=$(awk -F'_' '{print $1}' /sys/kernel/sched_ext/root/ops)
-    SCX_VERSION=$(scx_"$SCX" --version)
-else
-    SCX="none"
-	SCX_VERSION=""
+
+# Set defaults as none
+SCX="none"
+SCX_VERSION=""
+# update if we find them below
+	
+if [ -x $(which scxctl) ]; then
+	# sequence outputs: running Lavd in Auto mode | running lavd in auto mode | lavd in auto mode | lavd
+    SCX=$(scxctl get | awk '{print tolower($0)}' | awk -F'running[[:space:]]' '{print $2}' | awk -F'[[:space:]]' '{print $1}')
+	echo "Found scx_$SCX via scxctl"
 fi
+
+# Attempt fallback if scxctl is not available
+if [ "$SCX" = "none" ] && [ -f /sys/kernel/sched_ext/root/ops ]; then
+	# sequence outputs: lavd_1.0.21_g7298f797_x86_64_unknown_linux_gnu | lavd
+    SCX=$(cat /sys/kernel/sched_ext/root/ops | awk -F_ '{print $1}')
+	echo "Found scx_$SCX via /sys/kernel/sched_ext/root/ops"
+fi
+
+if [ "$SCX" != "none" ]; then
+	# sequence outputs: scx_lavd 1.0.21-g7298f797 x86_64-unknown-linux-gnu | 1.0.21-g7298f797 | 1.0.21
+	SCX_VERSION=$(scx_"$SCX" --version | awk -F'[[:space:]]' '{print $2}' | awk -F'-' '{print $1}')
+	echo "$SCX is version $SCX_VERSION"
+fi
+
 VERSION=$(pacman -Qi cachyos-benchmarker | grep "Version         :")
 # allow more open files, needed by perf bench msg
 ulimit -n 4096

--- a/cachyos-benchmarker
+++ b/cachyos-benchmarker
@@ -219,27 +219,22 @@ SCX_VERSION=""
 	
 SCXCTL=$(command -v scxctl)
 if [ -n "$SCXCTL" ]; then
-	# sequence outputs: running Lavd in Auto mode | running lavd in auto mode | lavd in auto mode | lavd
-    SCX=$(scxctl get | awk '{print tolower($0)}' | awk -F'running[[:space:]]' '{print $2}' | awk -F'[[:space:]]' '{print $1}')
+	# sequence outputs: running Lavd in Auto mode | lavd
+    SCX=$(scxctl get | sed -rn 's/^running (.*) in (.*) mode$/\L\1/p')
 	if [ -n "$SCX" ]; then
 		echo "Found scx_$SCX via scxctl"
+	else
+		SCX="none"
 	fi
 fi
 
-# Attempt fallback if scxctl is not available
-if [ "$SCX" = "none" ] && [ -f "/sys/kernel/sched_ext/root/ops" ]; then
-	# sequence outputs: lavd_1.0.21_g7298f797_x86_64_unknown_linux_gnu | lavd
-    SCX=$(cat "/sys/kernel/sched_ext/root/ops" | awk -F_ '{print $1}')
-	if [ -n "$SCX" ]; then
-		echo "Found scx_$SCX via /sys/kernel/sched_ext/root/ops"
-	fi
-fi
-
-if [ -n "$SCX" ] && [ "$SCX" != "none" ]; then
-	# sequence outputs: scx_lavd 1.0.21-g7298f797 x86_64-unknown-linux-gnu | 1.0.21-g7298f797 | 1.0.21
-	SCX_VERSION=$(scx_"$SCX" --version | awk -F'[[:space:]]' '{print $2}' | awk -F'-' '{print $1}')
+if [ "$SCX" != "none" ]; then
+	# sequence outputs: scx_lavd 1.0.21-g7298f797 x86_64-unknown-linux-gnu | 1.0.21-g7298f797
+	SCX_VERSION=$(scx_"$SCX" --version | sed -rn 's/^scx_(.*) (.*) (.*)$/\2/p')
 	if [ -n "$SCX_VERSION" ]; then
 		echo "$SCX is version $SCX_VERSION"
+	else
+		SCX_VERSION=""
 	fi
 fi
 

--- a/cachyos-benchmarker
+++ b/cachyos-benchmarker
@@ -227,16 +227,20 @@ if [ -n "$SCXCTL" ]; then
 fi
 
 # Attempt fallback if scxctl is not available
-if [ "$SCX" = "none" ] && [ -f "/sys/kernel/sched_ext/root/ops" ]; then
+if [ "$SCX" = "none" ] && [ -f /sys/kernel/sched_ext/root/ops ]; then
 	# sequence outputs: lavd_1.0.21_g7298f797_x86_64_unknown_linux_gnu | lavd
     SCX=$(cat /sys/kernel/sched_ext/root/ops | awk -F_ '{print $1}')
-	echo "Found scx_$SCX via /sys/kernel/sched_ext/root/ops"
+	if [ -n "$SCX" ]; then
+		echo "Found scx_$SCX via /sys/kernel/sched_ext/root/ops"
+	fi
 fi
 
 if [ "$SCX" != "none" ]; then
 	# sequence outputs: scx_lavd 1.0.21-g7298f797 x86_64-unknown-linux-gnu | 1.0.21-g7298f797 | 1.0.21
 	SCX_VERSION=$(scx_"$SCX" --version | awk -F'[[:space:]]' '{print $2}' | awk -F'-' '{print $1}')
-	echo "$SCX is version $SCX_VERSION"
+	if [ -n "$SCX" ] && [ -x "$SCX_VERSION"]; then
+		echo "$SCX is version $SCX_VERSION"
+	fi
 fi
 
 VERSION=$(pacman -Qi cachyos-benchmarker | grep "Version         :")

--- a/cachyos-benchmarker
+++ b/cachyos-benchmarker
@@ -235,10 +235,10 @@ if [ "$SCX" = "none" ] && [ -f /sys/kernel/sched_ext/root/ops ]; then
 	fi
 fi
 
-if [ "$SCX" != "none" ]; then
+if [ -n "$SCX" ] && [ "$SCX" != "none" ]; then
 	# sequence outputs: scx_lavd 1.0.21-g7298f797 x86_64-unknown-linux-gnu | 1.0.21-g7298f797 | 1.0.21
 	SCX_VERSION=$(scx_"$SCX" --version | awk -F'[[:space:]]' '{print $2}' | awk -F'-' '{print $1}')
-	if [ -n "$SCX" ] && [ -x "$SCX_VERSION"]; then
+	if [ -x "$SCX_VERSION"]; then
 		echo "$SCX is version $SCX_VERSION"
 	fi
 fi

--- a/cachyos-benchmarker
+++ b/cachyos-benchmarker
@@ -220,9 +220,9 @@ SCX_VERSION=""
 SCXCTL=$(command -v scxctl)
 if [ -n "$SCXCTL" ]; then
 	# sequence outputs: running Lavd in Auto mode | lavd
-    SCX=$(scxctl get | sed -rn 's/^running (.*) in (.*) mode$/\L\1/p')
+    SCX=$(scxctl get | sed -rn 's/^running (.*) in (.*) mode$/scx_\L\1/p')
 	if [ -n "$SCX" ]; then
-		echo "Found scx_$SCX via scxctl"
+		echo "Found $SCX via scxctl"
 	else
 		SCX="none"
 	fi
@@ -230,7 +230,7 @@ fi
 
 if [ "$SCX" != "none" ]; then
 	# sequence outputs: scx_lavd 1.0.21-g7298f797 x86_64-unknown-linux-gnu | 1.0.21-g7298f797
-	SCX_VERSION=$(scx_"$SCX" --version | sed -rn 's/^scx_(.*) (.*) (.*)$/\2/p')
+	SCX_VERSION=$($SCX --version | sed -rn 's/^scx_(.*) (.*) (.*)$/\2/p')
 	if [ -n "$SCX_VERSION" ]; then
 		echo "$SCX is version $SCX_VERSION"
 	else

--- a/cachyos-benchmarker
+++ b/cachyos-benchmarker
@@ -212,7 +212,7 @@ KERNVER="6.14.7"
 # system info will be logged
 SYSINFO=$(inxi -CmSz -c0 -y-1 | sed -e "s/Array.*:.*//;/^\s*$/d")
 if [ -f /sys/kernel/sched_ext/root/ops ]; then
-    SCX=$(cat /sys/kernel/sched_ext/root/ops)
+    SCX=$(awk -F'_' '{print $1}' /sys/kernel/sched_ext/root/ops)
     SCX_VERSION=$(scx_$SCX --version)
 else
     SCX="none"

--- a/cachyos-benchmarker
+++ b/cachyos-benchmarker
@@ -217,14 +217,17 @@ SCX="none"
 SCX_VERSION=""
 # update if we find them below
 	
-if [ -x $(which scxctl) ]; then
+SCXCTL=$(command -v scxctl)
+if [ -n "$SCXCTL" ]; then
 	# sequence outputs: running Lavd in Auto mode | running lavd in auto mode | lavd in auto mode | lavd
     SCX=$(scxctl get | awk '{print tolower($0)}' | awk -F'running[[:space:]]' '{print $2}' | awk -F'[[:space:]]' '{print $1}')
-	echo "Found scx_$SCX via scxctl"
+	if [ -n "$SCX" ]; then
+		echo "Found scx_$SCX via scxctl"
+	fi
 fi
 
 # Attempt fallback if scxctl is not available
-if [ "$SCX" = "none" ] && [ -f /sys/kernel/sched_ext/root/ops ]; then
+if [ "$SCX" = "none" ] && [ -f "/sys/kernel/sched_ext/root/ops" ]; then
 	# sequence outputs: lavd_1.0.21_g7298f797_x86_64_unknown_linux_gnu | lavd
     SCX=$(cat /sys/kernel/sched_ext/root/ops | awk -F_ '{print $1}')
 	echo "Found scx_$SCX via /sys/kernel/sched_ext/root/ops"

--- a/cachyos-benchmarker
+++ b/cachyos-benchmarker
@@ -212,31 +212,22 @@ KERNVER="6.14.7"
 # system info will be logged
 SYSINFO=$(inxi -CmSz -c0 -y-1 | sed -e "s/Array.*:.*//;/^\s*$/d")
 
+echo "Kernel: $(uname -r)"
+
 # Set defaults as none
 SCX="none"
 SCX_VERSION=""
 # update if we find them below
-	
-SCXCTL=$(command -v scxctl)
-if [ -n "$SCXCTL" ]; then
-	# sequence outputs: running Lavd in Auto mode | lavd
-    SCX=$(scxctl get | sed -rn 's/^running (.*) in (.*) mode$/scx_\L\1/p')
-	if [ -n "$SCX" ]; then
-		echo "Found $SCX via scxctl"
-	else
-		SCX="none"
+
+if [ -f "/sys/kernel/sched_ext/root/ops" ]; then
+	TMP=$(cat "/sys/kernel/sched_ext/root/ops")
+	if [ -n "$TMP" ]; then
+		SCX=$(awk -F'[[:digit:]]' '{print $1}' "/sys/kernel/sched_ext/root/ops" | awk -F'[[:digit:]]' '{print $1}' | sed -rn 's/^(.*)_$/\1/p')
+		SCX_VERSION=$(sed -rn 's/^[^0-9]*([0-9]+(\.[0-9]+)+).*$/\1/p' "/sys/kernel/sched_ext/root/ops")
 	fi
 fi
 
-if [ "$SCX" != "none" ]; then
-	# sequence outputs: scx_lavd 1.0.21-g7298f797 x86_64-unknown-linux-gnu | 1.0.21-g7298f797
-	SCX_VERSION=$($SCX --version | sed -rn 's/^scx_(.*) (.*) (.*)$/\2/p')
-	if [ -n "$SCX_VERSION" ]; then
-		echo "$SCX is version $SCX_VERSION"
-	else
-		SCX_VERSION=""
-	fi
-fi
+echo "Sched-Ext: $SCX $SCX_VERSION"
 
 VERSION=$(pacman -Qi cachyos-benchmarker | grep "Version         :")
 # allow more open files, needed by perf bench msg

--- a/cachyos-benchmarker
+++ b/cachyos-benchmarker
@@ -227,9 +227,9 @@ if [ -n "$SCXCTL" ]; then
 fi
 
 # Attempt fallback if scxctl is not available
-if [ "$SCX" = "none" ] && [ -f /sys/kernel/sched_ext/root/ops ]; then
+if [ "$SCX" = "none" ] && [ -f "/sys/kernel/sched_ext/root/ops" ]; then
 	# sequence outputs: lavd_1.0.21_g7298f797_x86_64_unknown_linux_gnu | lavd
-    SCX=$(cat /sys/kernel/sched_ext/root/ops | awk -F_ '{print $1}')
+    SCX=$(cat "/sys/kernel/sched_ext/root/ops" | awk -F_ '{print $1}')
 	if [ -n "$SCX" ]; then
 		echo "Found scx_$SCX via /sys/kernel/sched_ext/root/ops"
 	fi

--- a/cachyos-benchmarker
+++ b/cachyos-benchmarker
@@ -213,9 +213,10 @@ KERNVER="6.14.7"
 SYSINFO=$(inxi -CmSz -c0 -y-1 | sed -e "s/Array.*:.*//;/^\s*$/d")
 if [ -f /sys/kernel/sched_ext/root/ops ]; then
     SCX=$(awk -F'_' '{print $1}' /sys/kernel/sched_ext/root/ops)
-    SCX_VERSION=$(scx_$SCX --version)
+    SCX_VERSION=$(scx_"$SCX" --version)
 else
     SCX="none"
+	SCX_VERSION=""
 fi
 VERSION=$(pacman -Qi cachyos-benchmarker | grep "Version         :")
 # allow more open files, needed by perf bench msg


### PR DESCRIPTION
The following errors can be found, depending on which scheduler is selected.

```sh
/usr/bin/cachyos-benchmarker: line 214: scx_beerland_1.0.5_g7298f797_x86_64_unknown_linux_gnu: command not found
```

```sh
/usr/bin/cachyos-benchmarker: line 214: scx_bpfland_1.0.20_g7298f797_x86_64_unknown_linux_gnu: command not found
```

```sh
/usr/bin/cachyos-benchmarker: line 214: scx_cosmos_1.0.7_g7298f797_x86_64_unknown_linux_gnu: command not found
```

```sh
/usr/bin/cachyos-benchmarker: line 214: scx_flash_1.0.18_g7298f797_x86_64_unknown_linux_gnu: command not found
```

```sh
/usr/bin/cachyos-benchmarker: line 214: scx_lavd_1.0.21_g7298f797_x86_64_unknown_linux_gnu: command not found
```

```sh
/usr/bin/cachyos-benchmarker: line 214: scx_p2dq_1.0.25_g7298f797_x86_64_unknown_linux_gnu: command not found
```

```sh
/usr/bin/cachyos-benchmarker: line 214: scx_tickless_1.0.11_g7298f797_x86_64_unknown_linux_gnu: command not found
```

```sh
/usr/bin/cachyos-benchmarker: line 214: scx_rustland_1.0.20_g7298f797_x86_64_unknown_linux_gnu: command not found
```

```sh
/usr/bin/cachyos-benchmarker: line 214: scx_rusty_1.0.20_g7298f797_x86_64_unknown_linux_gnu: command not found
```

This resolves those errors, by adjusting the SCX checking logic, in this case I'm using `scxctl get`