### PR TITLE
Append Scheduler to Kernel name for graph comparisons

### DIFF
--- a/benchmark_scraper.py
+++ b/benchmark_scraper.py
@@ -23,10 +23,12 @@ def parse_log_files():
                 print(f"Warning: Could not extract kernel version from file: {file}")
                 continue
 
+            scx_match = re.search(r'SCX Scheduler: (\S+)', data_text)
             scx_version_match = re.search(r'SCX Version: (\S+)', data_text)
-            if scx_version_match:
+            if scx_match and scx_version_match:
+                scx = scx_match.group(1)
                 scx_version = scx_version_match.group(1)
-                kernel_version = ''.join([kernel_version, '_', scx_version])
+                kernel_version = ''.join([kernel_version, '_scx_', scx, '_', scx_version])
 
             system_info_match = re.search(r'System:(.*?)$', data_text, re.DOTALL)
             if system_info_match:

--- a/benchmark_scraper.py
+++ b/benchmark_scraper.py
@@ -23,6 +23,11 @@ def parse_log_files():
                 print(f"Warning: Could not extract kernel version from file: {file}")
                 continue
 
+            scx_version_match = re.search(r'SCX Version: (\S+)', data_text)
+            if scx_version_match:
+                scx_version = scx_version_match.group(1)
+                kernel_version = ''.join([kernel_version, '_', scx_version])
+
             system_info_match = re.search(r'System:(.*?)$', data_text, re.DOTALL)
             if system_info_match:
                 system_info = system_info_match.group(1).strip()

--- a/benchmark_scraper.py
+++ b/benchmark_scraper.py
@@ -28,7 +28,7 @@ def parse_log_files():
             if scx_match and scx_version_match:
                 scx = scx_match.group(1)
                 scx_version = scx_version_match.group(1)
-                kernel_version = ''.join([kernel_version, '_scx_', scx, '_', scx_version])
+                kernel_version = ''.join([kernel_version, '_', scx, '_', scx_version])
 
             system_info_match = re.search(r'System:(.*?)$', data_text, re.DOTALL)
             if system_info_match:


### PR DESCRIPTION
I have adjusted the benchmark scraper script so that the SCX Version is appended to the Kernel, so that it is possible to see different Schedulers via SCX on the graphs.

<img width="1200" height="1879" alt="image" src="https://github.com/user-attachments/assets/8302d010-6538-49d4-8cc8-f5d0415f05ed" />

The formatting shown in the screenshot for `kernel_scx_version` also needs https://github.com/CachyOS/cachyos-benchmarker/pull/10 in order to save the information into the report/log with the following format

```
SCX Scheduler: beerland

SCX Version: 1.0.5
```
