### PR TITLE
Handle missing underscore in scx name and missing version in ops file

### DIFF
--- a/cachyos-benchmarker
+++ b/cachyos-benchmarker
@@ -224,6 +224,9 @@ if [ -f "/sys/kernel/sched_ext/root/ops" ]; then
 	if [ -n "$TMP" ]; then
 		SCX=$(awk -F'[[:digit:]]' '{print $1}' "/sys/kernel/sched_ext/root/ops" | sed -rn 's/^(.*)_?$/\1/p')
 		SCX_VERSION=$(sed -rn 's/^[^0-9]*([0-9]+(\.[0-9]+)+).*$/\1/p' "/sys/kernel/sched_ext/root/ops")
+		if [ ! -n "$SCX_VERSION" ] && [ -x $(which "scx_$SCX") ]; then
+			SCX_VERSION=$("scx_$SCX" --version | awk -F' ' '{print $2}')
+		fi
 	fi
 fi
 

--- a/cachyos-benchmarker
+++ b/cachyos-benchmarker
@@ -222,7 +222,7 @@ SCX_VERSION=""
 if [ -f "/sys/kernel/sched_ext/root/ops" ]; then
 	TMP=$(cat "/sys/kernel/sched_ext/root/ops")
 	if [ -n "$TMP" ]; then
-		SCX=$(awk -F'[[:digit:]]' '{print $1}' "/sys/kernel/sched_ext/root/ops" | sed -rn 's/^(.*)_$/\1/p')
+		SCX=$(awk -F'[[:digit:]]' '{print $1}' "/sys/kernel/sched_ext/root/ops" | sed -rn 's/^(.*)_?$/\1/p')
 		SCX_VERSION=$(sed -rn 's/^[^0-9]*([0-9]+(\.[0-9]+)+).*$/\1/p' "/sys/kernel/sched_ext/root/ops")
 	fi
 fi

--- a/cachyos-benchmarker
+++ b/cachyos-benchmarker
@@ -222,7 +222,7 @@ SCX_VERSION=""
 if [ -f "/sys/kernel/sched_ext/root/ops" ]; then
 	TMP=$(cat "/sys/kernel/sched_ext/root/ops")
 	if [ -n "$TMP" ]; then
-		SCX=$(awk -F'[[:digit:]]' '{print $1}' "/sys/kernel/sched_ext/root/ops" | sed -rn 's/^(.*)_?$/\1/p')
+		SCX=$(awk -F'[[:digit:]]' '{print $1}' "/sys/kernel/sched_ext/root/ops" | sed 's/_$//')
 		SCX_VERSION=$(sed -rn 's/^[^0-9]*([0-9]+(\.[0-9]+)+).*$/\1/p' "/sys/kernel/sched_ext/root/ops")
 		if [ ! -n "$SCX_VERSION" ] && [ -x $(which "scx_$SCX") ]; then
 			SCX_VERSION=$("scx_$SCX" --version | awk -F' ' '{print $2}')


### PR DESCRIPTION
This is a fix/workaround for https://github.com/sched-ext/scx/issues/3411